### PR TITLE
fix: use correct dependency-review parameter for license allowlisting

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -186,10 +186,11 @@ jobs:
             MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0,
             LGPL-3.0-only, LGPL-3.0-or-later, LGPL-2.1-only, LGPL-2.1-or-later,
             Unlicense, 0BSD, CC0-1.0, Artistic-2.0, Zlib, BSL-1.0, PostgreSQL,
-            BlueOak-1.0.0,
-            BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang
-          # Some deps (go-ethereum, OTel detectors) have undetected licenses on GitHub
-          allow-packages: >-
+            BlueOak-1.0.0
+          # Whitelist deps with compound/undetected licenses (Go ecosystem, go-ethereum, OTel)
+          allow-dependencies-licenses: >-
+            pkg:golang/golang.org/x/sys,
+            pkg:golang/google.golang.org/protobuf,
             pkg:golang/github.com/ethereum/go-ethereum,
             pkg:golang/github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp
 


### PR DESCRIPTION
Fix dependency review failures:
- `allow-packages` is not a valid input — replaced with `allow-dependencies-licenses`
- Moved compound-license deps (golang.org/x/sys, protobuf) to per-package allowlist instead of trying to match SPDX compound expressions
- Whitelists go-ethereum and OTel GCP detector (undetected licenses)