### PR TITLE
fix: correct sed backreference in k8s manifest updater and remove unbuilt images from Trivy scan

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -162,9 +162,9 @@ jobs:
         image:
           - orchestrator
           - api
-          - technical-agent
-          - trend-agent
-          - risk-agent
+          # NOTE: Agent images (technical-agent, trend-agent, risk-agent) are not
+          # built/pushed in this workflow yet. Add them here once agent Docker
+          # builds are added to the build-and-push matrix.
 
     steps:
       - name: Run Trivy vulnerability scanner
@@ -198,7 +198,7 @@ jobs:
           SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
 
           find deployments/k8s -name '*.yaml' -type f | while read file; do
-            sed -i "s|image: ghcr.io/${{ github.repository_owner }}/cryptofunk-.*:.*|image: ghcr.io/${{ github.repository_owner }}/cryptofunk-\1:main-${SHORT_SHA}|g" "$file"
+            sed -i -E "s|image: ghcr.io/${{ github.repository_owner }}/cryptofunk-([^:]+):.*|image: ghcr.io/${{ github.repository_owner }}/cryptofunk-\1:main-${SHORT_SHA}|g" "$file"
           done
 
       - name: Commit and push updated manifests


### PR DESCRIPTION
## Fixes

1. **Update K8s Manifests** — `sed` used `\1` backreference without a capture group. Changed to `-E` (extended regex) with proper `([^:]+)` capture group.
2. **Security Scan Images** — Removed `trend-agent`, `technical-agent`, `risk-agent` from Trivy scan matrix since they are not built/pushed in this workflow. Added comment to re-add once agent Docker builds are wired up.

Both were causing CI failures on main.