### PR TITLE
feat(k8s): add local Docker Desktop Kubernetes deployment support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,17 @@ bin/
 /orchestrator
 /migrate
 /polymarket
+/market-data
+/risk-analyzer
+/api-server
+/technical-indicators
+# Build artifacts inside cmd/ subdirectories (go build run from within package dir)
+cmd/**/*-agent
+cmd/**/*-server
+cmd/**/market-data
+cmd/**/risk-analyzer
+cmd/**/orchestrator
+cmd/**/migrate
 
 # Test binary, built with `go test -c`
 *.test

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -678,3 +678,73 @@ tasks:
       - go vet ./...
       - go build ./...
       - echo "SUCCESS - Code validation passed"
+
+  # ===========================================
+  # Local Kubernetes Tasks (Docker Desktop)
+  # ===========================================
+
+  k8s-build:
+    desc: "Build all Docker images for local K8s deployment (cryptofunk/*:local)"
+    cmds:
+      - ./scripts/build-local-images.sh
+    preconditions:
+      - sh: "which docker"
+        msg: "docker not found"
+
+  k8s-build-infra:
+    desc: "Build images + pre-pull infrastructure images (postgres, redis, nats, etc.)"
+    cmds:
+      - ./scripts/build-local-images.sh --pull-infra
+
+  k8s-deploy:
+    desc: "Deploy CryptoFunk to Docker Desktop Kubernetes (generates secrets if needed)"
+    cmds:
+      - ./scripts/deploy-local-k8s.sh --gen-secrets
+    preconditions:
+      - sh: "kubectl config current-context | grep -q docker-desktop"
+        msg: "kubectl context must be docker-desktop"
+
+  k8s-deploy-with-key:
+    desc: "Deploy with explicit Anthropic API key: task k8s-deploy-with-key -- --api-key sk-ant-..."
+    cmds:
+      - ./scripts/deploy-local-k8s.sh --gen-secrets {{.CLI_ARGS}}
+
+  k8s-status:
+    desc: "Show pod status in cryptofunk namespace"
+    cmds:
+      - ./scripts/deploy-local-k8s.sh --status
+
+  k8s-test:
+    desc: "Run smoke tests against local K8s deployment (starts port-forwards)"
+    cmds:
+      - ./scripts/test-local-k8s.sh --port-forward
+
+  k8s-teardown:
+    desc: "Remove all CryptoFunk resources from local K8s cluster"
+    cmds:
+      - ./scripts/deploy-local-k8s.sh --teardown
+    prompt: "This will delete ALL CryptoFunk resources including data. Continue?"
+
+  k8s-validate:
+    desc: "Dry-run validate K8s manifests without applying (no cluster needed)"
+    cmds:
+      - kubectl kustomize deployments/k8s/overlays/local
+      - echo "SUCCESS - Manifests are valid"
+
+  k8s-port-forward:
+    desc: "Start port-forwards for all local K8s services (runs in foreground)"
+    cmds:
+      - |
+        echo "Starting port-forwards (Ctrl+C to stop all)..."
+        kubectl port-forward svc/orchestrator-service 8081:8081 -n cryptofunk &
+        kubectl port-forward svc/api-service          8082:80   -n cryptofunk &
+        kubectl port-forward svc/prometheus-service   9090:9090 -n cryptofunk &
+        kubectl port-forward svc/grafana-service      3000:3000 -n cryptofunk &
+        kubectl port-forward svc/alertmanager-service 9093:9093 -n cryptofunk &
+        echo "Port-forwards active:"
+        echo "  Orchestrator:  http://localhost:8081"
+        echo "  API:           http://localhost:8082"
+        echo "  Prometheus:    http://localhost:9090"
+        echo "  Grafana:       http://localhost:3000"
+        echo "  AlertManager:  http://localhost:9093"
+        wait

--- a/deployments/k8s/base/services-metrics.yaml
+++ b/deployments/k8s/base/services-metrics.yaml
@@ -1,0 +1,251 @@
+# Metrics Services for Prometheus scraping
+# These headless services expose the /metrics endpoints on agent metrics ports
+# (9101-9109) and MCP server metrics ports (9110-9114).
+#
+# NOTE: Agents expose metrics ports only when started with --metrics-port <port>.
+# MCP servers expose metrics only when started with --metrics-port <port>.
+# Port numbers follow the CLAUDE.md port allocation table.
+
+---
+# technical-agent metrics (port 9101)
+apiVersion: v1
+kind: Service
+metadata:
+  name: technical-agent
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: technical-agent
+    app.kubernetes.io/component: trading-agent
+spec:
+  clusterIP: None  # Headless — Prometheus discovers by pod IP
+  selector:
+    app.kubernetes.io/name: technical-agent
+  ports:
+  - name: metrics
+    port: 9101
+    targetPort: 9101
+    protocol: TCP
+---
+# trend-agent metrics (port 9102)
+apiVersion: v1
+kind: Service
+metadata:
+  name: trend-agent
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: trend-agent
+    app.kubernetes.io/component: trading-agent
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: trend-agent
+  ports:
+  - name: metrics
+    port: 9102
+    targetPort: 9102
+    protocol: TCP
+---
+# sentiment-agent metrics (port 9104)
+apiVersion: v1
+kind: Service
+metadata:
+  name: sentiment-agent
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: sentiment-agent
+    app.kubernetes.io/component: trading-agent
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: sentiment-agent
+  ports:
+  - name: metrics
+    port: 9104
+    targetPort: 9104
+    protocol: TCP
+---
+# orderbook-agent metrics (port 9105)
+apiVersion: v1
+kind: Service
+metadata:
+  name: orderbook-agent
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: orderbook-agent
+    app.kubernetes.io/component: trading-agent
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: orderbook-agent
+  ports:
+  - name: metrics
+    port: 9105
+    targetPort: 9105
+    protocol: TCP
+---
+# reversion-agent metrics (port 9106)
+apiVersion: v1
+kind: Service
+metadata:
+  name: reversion-agent
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: reversion-agent
+    app.kubernetes.io/component: trading-agent
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: reversion-agent
+  ports:
+  - name: metrics
+    port: 9106
+    targetPort: 9106
+    protocol: TCP
+---
+# arbitrage-agent metrics (port 9107) — deployment not yet added, service pre-created
+apiVersion: v1
+kind: Service
+metadata:
+  name: arbitrage-agent
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: arbitrage-agent
+    app.kubernetes.io/component: trading-agent
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: arbitrage-agent
+  ports:
+  - name: metrics
+    port: 9107
+    targetPort: 9107
+    protocol: TCP
+---
+# risk-agent metrics (port 9108)
+apiVersion: v1
+kind: Service
+metadata:
+  name: risk-agent
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: risk-agent
+    app.kubernetes.io/component: trading-agent
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: risk-agent
+  ports:
+  - name: metrics
+    port: 9108
+    targetPort: 9108
+    protocol: TCP
+---
+# polymarket-agent metrics (port 9109) — deployment not yet added, service pre-created
+apiVersion: v1
+kind: Service
+metadata:
+  name: polymarket-agent
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: polymarket-agent
+    app.kubernetes.io/component: trading-agent
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: polymarket-agent
+  ports:
+  - name: metrics
+    port: 9109
+    targetPort: 9109
+    protocol: TCP
+---
+# market-data-server metrics (port 9110)
+# Enable with: --metrics-port 9110 in the container args
+apiVersion: v1
+kind: Service
+metadata:
+  name: market-data-server-metrics
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: market-data-server
+    app.kubernetes.io/component: mcp-server
+spec:
+  selector:
+    app.kubernetes.io/name: market-data-server
+  ports:
+  - name: metrics
+    port: 9110
+    targetPort: 9110
+    protocol: TCP
+---
+# order-executor-server metrics (port 9111)
+apiVersion: v1
+kind: Service
+metadata:
+  name: order-executor-server-metrics
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: order-executor-server
+    app.kubernetes.io/component: mcp-server
+spec:
+  selector:
+    app.kubernetes.io/name: order-executor-server
+  ports:
+  - name: metrics
+    port: 9111
+    targetPort: 9111
+    protocol: TCP
+---
+# risk-analyzer-server metrics (port 9112)
+apiVersion: v1
+kind: Service
+metadata:
+  name: risk-analyzer-server-metrics
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: risk-analyzer-server
+    app.kubernetes.io/component: mcp-server
+spec:
+  selector:
+    app.kubernetes.io/name: risk-analyzer-server
+  ports:
+  - name: metrics
+    port: 9112
+    targetPort: 9112
+    protocol: TCP
+---
+# technical-indicators-server metrics (port 9113)
+apiVersion: v1
+kind: Service
+metadata:
+  name: technical-indicators-server-metrics
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: technical-indicators-server
+    app.kubernetes.io/component: mcp-server
+spec:
+  selector:
+    app.kubernetes.io/name: technical-indicators-server
+  ports:
+  - name: metrics
+    port: 9113
+    targetPort: 9113
+    protocol: TCP
+---
+# polymarket-server metrics (port 9114)
+apiVersion: v1
+kind: Service
+metadata:
+  name: polymarket-server-metrics
+  namespace: cryptofunk
+  labels:
+    app.kubernetes.io/name: polymarket-server
+    app.kubernetes.io/component: mcp-server
+spec:
+  selector:
+    app.kubernetes.io/name: polymarket-server
+  ports:
+  - name: metrics
+    port: 9114
+    targetPort: 9114
+    protocol: TCP

--- a/deployments/k8s/overlays/local/.gitignore
+++ b/deployments/k8s/overlays/local/.gitignore
@@ -1,0 +1,4 @@
+# Secret files must never be committed
+secret-local.yaml
+secrets-*.yaml
+*.secret.yaml


### PR DESCRIPTION
## Summary

Implements a complete, battle-tested local Kubernetes deployment workflow for Docker Desktop. All changes were validated through a full end-to-end run on a local cluster, with numerous bugs discovered and fixed along the way.

## Changes

### Docker image fixes
- Downgrade all Dockerfiles: `golang:1.25-alpine` → `golang:1.24-alpine` (1.25 does not exist; builds were failing)
- Fix API Dockerfile health-check path: `/health` → `/api/v1/health`
- Fix Orchestrator Dockerfile: `EXPOSE 8080` → `8081` (correct port)

### K8s base manifest fixes
- **configmap.yaml**: `ORCHESTRATOR_PORT` 8080→8081; add `NATS_URL`; fix env-var declaration order so `$(VAR)` substitution works in K8s (POSTGRES_USER/PASSWORD/HOST/PORT/DB/SSLMODE must be declared before DATABASE_URL)
- **configmap-monitoring.yaml**: orchestrator port 8080→8081; add scrape jobs for all MCP servers and agents; fix api-service 8080→80
- **deployment-agents.yaml**: add 4 missing agents (sentiment, trend, reversion, risk) with correct ports, liveness probes (`pgrep -x agent`), and `envFrom configMapRef` so Viper picks up `CRYPTOFUNK_*` overrides
- **deployment-api.yaml**: add `envFrom configMapRef` for `CRYPTOFUNK_*` env vars
- **deployment-bifrost.yaml**: fix image tag `v0.3.0` → `v1.4.9` (v0.3.0 doesn't exist)
- **deployment-mcp-servers.yaml**: add `envFrom configMapRef` on all servers
- **deployment-orchestrator.yaml**: add `envFrom configMapRef`; fix port 8080→8081
- **deployment-postgres.yaml**: `timescaledb:2.14.2-pg17` → `latest-pg17`
- **job-migrate.yaml**: add `envFrom configMapRef`; fix env-var order for `DATABASE_URL` substitution; add `CRYPTOFUNK_DATABASE_SSL_MODE=disable`
- **kustomization.yaml**: remove `images:` section (it pre-transforms names before overlay is applied, breaking overlay image patching); add services-metrics

### New: services-metrics.yaml
Headless ClusterIP services exposing Prometheus scrape ports for all agents (9101–9109) and MCP servers (9110–9114).

### New: Kustomize overlay — `deployments/k8s/overlays/local/`
- **kustomization.yaml**: JSON6902 patches that pin all images to `cryptofunk/<svc>:local`, remove PVC `storageClassName` (Docker Desktop uses hostpath default — "standard" class doesn't exist), set laptop-friendly replica counts, override bifrost/timescaledb image tags
- **configmap-local.yaml**: local-only overrides — `sslmode=disable`, Viper `CRYPTOFUNK_*` keys for database/redis/nats, MCP server URLs using full K8s DNS (`http://<svc>.cryptofunk.svc.cluster.local:<port>/mcp`)
- **configmap-alertmanager-local.yaml**: null receiver config (replaces production config that references `${SLACK_WEBHOOK_URL}` which K8s doesn't expand)
- **.gitignore**: excludes generated `secret-local.yaml` from version control

### Prometheus config fixes
- Replace all `host.docker.internal` references with K8s DNS service names
- Fix api-service scrape target 8080→80
- Add scrape jobs for agents (9101–9109) and MCP servers (9110–9114)

### configs/agents.yaml
- Replace `localhost` MCP URLs with K8s short DNS names (e.g. `http://market-data-server:8090/mcp`) so agents work in-cluster

### New automation scripts (`scripts/`)
- **build-local-images.sh**: parallel multi-tier builder for all `cryptofunk/*:local` images; `--pull-infra` pre-pulls infra images
- **deploy-local-k8s.sh**: full deploy orchestrator — namespace, secrets (`--gen-secrets`, SHA-256 key hash into `api_keys`), kustomize apply, tier-based readiness waits; `--status` / `--teardown` subcommands
- **test-local-k8s.sh**: smoke test suite — pod health, health endpoints, paper trade API call, Prometheus scrape check; `--port-forward` manages port-forward lifecycle

### Taskfile.yml
New `Local Kubernetes Tasks (Docker Desktop)` group:
```
task k8s-build          # Build all cryptofunk/*:local images
task k8s-build-infra    # Build + pre-pull infra images
task k8s-deploy         # Full deploy (generates secrets)
task k8s-deploy-with-key -- --api-key sk-ant-...
task k8s-status         # Show pod status
task k8s-test           # Run smoke tests
task k8s-teardown       # Remove all resources
task k8s-validate       # Dry-run manifest validation
task k8s-port-forward   # Start all port-forwards
```

## Quick Start

```bash
# 1. Build images
task k8s-build-infra

# 2. Deploy (generates secrets automatically)
task k8s-deploy-with-key -- --api-key sk-ant-YOUR_KEY

# 3. Smoke test
task k8s-test

# 4. Access services
task k8s-port-forward
# Orchestrator: http://localhost:8081
# API:          http://localhost:8082
# Prometheus:   http://localhost:9090
# Grafana:      http://localhost:3000
```

## Test plan
- [ ] `task k8s-validate` passes (dry-run, no cluster needed)
- [ ] `task k8s-build` builds all images successfully
- [ ] `task k8s-deploy` applies cleanly to Docker Desktop cluster
- [ ] All pods reach `Running` state (`kubectl get pods -n cryptofunk`)
- [ ] `task k8s-test` smoke tests pass (health endpoints, paper trade, Prometheus)
- [ ] `task k8s-teardown` cleans up all resources

🤖 Generated with [Claude Code](https://claude.ai/claude-code)