### PR TITLE
fix: map agent health status to valid DB enum values

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -72,8 +72,10 @@ node_modules/
 # Web/Dashboard (not needed for Go builds)
 web/
 
-# Worktrees
+# Worktrees and Claude artifacts
 *-worktrees/
+.claude/
+market-data
 
 # Terraform state
 infra/terraform/.terraform/

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -451,9 +451,13 @@ func (o *Orchestrator) handleHeartbeat(msg *nats.Msg) {
 	if o.db != nil {
 		go func() {
 			now := time.Now()
+			// Map health status to valid DB enum (STARTING/RUNNING/STOPPED/ERROR)
 			status := "RUNNING"
-			if heartbeat.Status != HealthStatusHealthy {
-				status = heartbeat.Status
+			switch heartbeat.Status {
+			case HealthStatusUnhealthy:
+				status = "ERROR"
+			case HealthStatusDegraded:
+				status = "RUNNING" // degraded is still running
 			}
 			agentStatus := &db.AgentStatus{
 				Name:          heartbeat.AgentName,


### PR DESCRIPTION
## Summary

- **Agent status persistence was broken for ALL agents** — the orchestrator passed raw heartbeat status values (`HEALTHY`, `DEGRADED`) to the `agent_status` table, but the `agent_state_type` enum only allows `STARTING`, `RUNNING`, `STOPPED`, `ERROR`. Every `UpsertAgentStatus` call failed silently.
- **Docker build context was 403MB** — `.claude/` worktrees and `market-data` binary were not excluded, causing OOM during parallel builds.

## Changes

### Orchestrator (`internal/orchestrator/orchestrator.go`)
Map health status to valid DB enum values in the heartbeat persistence handler:
- `HEALTHY` → `RUNNING`
- `DEGRADED` → `RUNNING` (degraded agents are still running)
- `UNHEALTHY` → `ERROR`

### Docker (`.dockerignore`)
Add `.claude/` and `market-data` to reduce build context from ~403MB to ~180MB.

## Testing

- All 43 Go test packages pass (`go test -short ./...`)
- Deployed to local K8s: 23/23 pods running
- Verified fix: `kubectl logs deployment/orchestrator` shows zero `Failed to persist agent status` errors
- All 8 agents now correctly show `RUNNING` in `/api/v1/agents` endpoint
- Before fix: every heartbeat cycle logged `invalid input value for enum agent_state_type: "healthy"`

## Test plan
- [x] Verify `go test ./internal/orchestrator/...` passes
- [x] Deploy to local K8s and confirm no persist errors in orchestrator logs
- [x] Confirm all agents show correct status via `/api/v1/agents`
- [x] Confirm orchestrator health endpoint shows healthy agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)