### PR TITLE
chore: upgrade Go 1.24 → 1.25

### DIFF
--- a/deployments/docker/Dockerfile.agent
+++ b/deployments/docker/Dockerfile.agent
@@ -6,7 +6,7 @@
 ARG AGENT_NAME=technical-agent
 
 # Stage 1: Builder
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 ARG AGENT_NAME
 

--- a/deployments/docker/Dockerfile.api
+++ b/deployments/docker/Dockerfile.api
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Multi-stage Dockerfile for API Server
 # Stage 1: Builder
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/deployments/docker/Dockerfile.mcp-server
+++ b/deployments/docker/Dockerfile.mcp-server
@@ -6,7 +6,7 @@
 ARG SERVER_NAME=market-data
 
 # Stage 1: Builder
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 ARG SERVER_NAME
 

--- a/deployments/docker/Dockerfile.migrate
+++ b/deployments/docker/Dockerfile.migrate
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Multi-stage Dockerfile for Database Migration Tool
 # Stage 1: Builder
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/deployments/docker/Dockerfile.orchestrator
+++ b/deployments/docker/Dockerfile.orchestrator
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Multi-stage Dockerfile for Orchestrator
 # Stage 1: Builder
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ajitpratap0/cryptofunk
 
-go 1.24.0
+go 1.25
 
 require (
 	firebase.google.com/go/v4 v4.18.0


### PR DESCRIPTION
## Summary

- Bumps minimum Go version from 1.24.0 to 1.25 in `go.mod`
- Updates 5 Dockerfiles (`Dockerfile.agent`, `Dockerfile.mcp-server`, `Dockerfile.api`, `Dockerfile.migrate`, `Dockerfile.orchestrator`) from `golang:1.24-alpine` to `golang:1.25-alpine`
- Runs `go mod tidy` to update `go.sum`
- Unblocks dependabot PR #88 (go-sdk 1.3.1 → 1.4.1), which requires Go ≥ 1.25

This replaces PR #90 which accidentally included paper trade pipeline changes (that PR will be closed).

## Why
go-sdk v1.4.1 declares `go 1.25` in its go.mod. The CI build fails at `go mod download` on Go 1.24 because the toolchain requirement is not met.

## Changes
- `go.mod`: `go 1.24.0` → `go 1.25`
- `deployments/docker/Dockerfile.{agent,mcp-server,api,migrate,orchestrator}`: `golang:1.24-alpine` → `golang:1.25-alpine`

Note: `Dockerfile.backtest` and `Dockerfile.go-service` were already on `golang:1.25-alpine`.

## Test Plan
- [ ] CI Build passes
- [ ] CI Lint passes
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)