### PR TITLE
fix(ci): run Go CI on web-only PRs to satisfy required status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ on:
       - 'deployments/grafana/**'
       - 'deployments/prometheus/**'
       - '.github/CODEOWNERS'
-      - 'web/**'
   schedule:
     # Run nightly at 2 AM UTC for thorough race detection
     - cron: '0 2 * * *'


### PR DESCRIPTION
## Summary

- Removes `web/**` from `pull_request` `paths-ignore` in CI workflow
- Go CI (Lint, Test, Build, Security Scan) now runs for all PRs including web-only changes

## Why

GitHub branch protection requires `Lint`, `Test`, `Build`, and `Security Scan` checks to pass before merging. When the CI workflow is skipped (due to `paths-ignore: web/**`), GitHub marks those checks as "expected" and blocks the PR permanently — even with `--admin` flag:

```
GraphQL: 4 of 5 required status checks are expected. (mergePullRequest)
```

This blocked PR #92 (Dependabot flatted bump, web-only change) indefinitely.

## Trade-off

Go CI now runs on web-only PRs (~3 min overhead). Acceptable since `go build ./...` + `go test -short ./...` are fast, and the alternative is permanently blocked PRs.

The `push` trigger still has `web/**` in `paths-ignore` to avoid triggering CI on main/develop pushes for web-only changes (e.g., dashboard deploys).

## Test plan

- [ ] Merge this PR first
- [ ] Re-run CI on PR #92 — `Lint`, `Test`, `Build`, `Security Scan` should now appear and pass
- [ ] PR #92 should become mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)