### PR TITLE
fix(lint): add return after t.Fatalf in coingecko_test.go to satisfy SA5011

### DIFF
--- a/internal/market/coingecko_test.go
+++ b/internal/market/coingecko_test.go
@@ -47,6 +47,7 @@ func TestNewCoinGeckoClient(t *testing.T) {
 
 			if client == nil {
 				t.Fatalf("Expected non-nil client for test case %q, but got nil", tt.name)
+				return
 			}
 
 			if client.timeout != defaultTimeout {
@@ -222,6 +223,7 @@ func TestGetPrice(t *testing.T) {
 
 			if result == nil {
 				t.Fatalf("Expected non-nil result for GetPrice(%q, %q), but got nil", tt.symbol, tt.vsCurrency)
+				return
 			}
 
 			if result.Symbol != tt.symbol {
@@ -304,6 +306,7 @@ func TestGetMarketChart(t *testing.T) {
 
 			if result == nil {
 				t.Fatalf("Expected non-nil result for GetMarketChart(%q, %d), but got nil", tt.symbol, tt.days)
+				return
 			}
 
 			if len(result.Prices) == 0 {


### PR DESCRIPTION
## Summary

- Adds `return` after each `t.Fatalf` call in `internal/market/coingecko_test.go` at lines 49, 224, and 306
- Staticcheck SA5011 reports false-positive nil pointer dereference warnings because it does not model `t.Fatalf` as a non-returning function
- This pattern is identical to the fix applied in PR #113 (`cache_test.go`)
- Unblocks dependabot PRs #88 and #112 which fail the required Lint check due to these violations

## Test plan
- [ ] `golangci-lint run ./internal/market/...` passes with no SA5011 errors
- [ ] Lint CI check passes on PRs #88 and #112 after they update their branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)