### PR TITLE
fix(db): link orders to positions via position_id FK (#128)

### DIFF
--- a/internal/db/orders.go
+++ b/internal/db/orders.go
@@ -517,6 +517,22 @@ func (db *DB) UpdateOrderPositionIDTx(ctx context.Context, tx pgx.Tx, orderID uu
 	return nil
 }
 
+// UpdateOrderPositionID links an order to a position using the connection pool.
+// Use this from code paths that don't already have a transaction open (e.g.
+// position_manager.OnOrderFilled). For transactional callers, prefer
+// UpdateOrderPositionIDTx.
+func (db *DB) UpdateOrderPositionID(ctx context.Context, orderID uuid.UUID, positionID uuid.UUID) error {
+	const q = `UPDATE orders SET position_id = $1, updated_at = NOW() WHERE id = $2`
+	result, err := db.pool.Exec(ctx, q, positionID, orderID)
+	if err != nil {
+		return fmt.Errorf("failed to set order position_id: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("order not found: %s", orderID)
+	}
+	return nil
+}
+
 // GetOrdersBySession retrieves all orders for a specific session
 func (db *DB) GetOrdersBySession(ctx context.Context, sessionID uuid.UUID) ([]*Order, error) {
 	query := `

--- a/internal/db/orders.go
+++ b/internal/db/orders.go
@@ -503,11 +503,14 @@ func (db *DB) GetOrderByID(ctx context.Context, orderID uuid.UUID) (*Order, erro
 	return db.GetOrder(ctx, orderID)
 }
 
+// updateOrderPositionIDSQL is shared by the Tx and non-Tx variants so the
+// query text stays in sync if the schema changes.
+const updateOrderPositionIDSQL = `UPDATE orders SET position_id = $1, updated_at = NOW() WHERE id = $2`
+
 // UpdateOrderPositionIDTx links an order to a position within an existing transaction.
 // This is called after a position is created/updated so the orders.position_id FK is populated.
 func (db *DB) UpdateOrderPositionIDTx(ctx context.Context, tx pgx.Tx, orderID uuid.UUID, positionID uuid.UUID) error {
-	const q = `UPDATE orders SET position_id = $1, updated_at = NOW() WHERE id = $2`
-	result, err := tx.Exec(ctx, q, positionID, orderID)
+	result, err := tx.Exec(ctx, updateOrderPositionIDSQL, positionID, orderID)
 	if err != nil {
 		return fmt.Errorf("failed to set order position_id: %w", err)
 	}
@@ -522,8 +525,7 @@ func (db *DB) UpdateOrderPositionIDTx(ctx context.Context, tx pgx.Tx, orderID uu
 // position_manager.OnOrderFilled). For transactional callers, prefer
 // UpdateOrderPositionIDTx.
 func (db *DB) UpdateOrderPositionID(ctx context.Context, orderID uuid.UUID, positionID uuid.UUID) error {
-	const q = `UPDATE orders SET position_id = $1, updated_at = NOW() WHERE id = $2`
-	result, err := db.pool.Exec(ctx, q, positionID, orderID)
+	result, err := db.pool.Exec(ctx, updateOrderPositionIDSQL, positionID, orderID)
 	if err != nil {
 		return fmt.Errorf("failed to set order position_id: %w", err)
 	}

--- a/internal/exchange/position_manager.go
+++ b/internal/exchange/position_manager.go
@@ -137,6 +137,14 @@ func (pm *PositionManager) OnOrderFilled(ctx context.Context, order *Order, fill
 	// Check if we have an existing position for this symbol
 	existingPos, hasPosition := pm.openPositions[order.Symbol]
 
+	// Capture the pre-existing position ID so we can link the order to it even
+	// if the position is fully closed (removed from openPositions) by the time
+	// we reach the linking step at the bottom.
+	var positionIDForOrder uuid.UUID
+	if hasPosition {
+		positionIDForOrder = existingPos.ID
+	}
+
 	if order.Side == OrderSideBuy {
 		// BUY order
 		if hasPosition {
@@ -157,6 +165,7 @@ func (pm *PositionManager) OnOrderFilled(ctx context.Context, order *Order, fill
 						if err != nil {
 							return err
 						}
+						positionIDForOrder = pm.openPositions[order.Symbol].ID
 					}
 				} else {
 					// Partially closing SHORT position
@@ -178,6 +187,7 @@ func (pm *PositionManager) OnOrderFilled(ctx context.Context, order *Order, fill
 			if err != nil {
 				return err
 			}
+			positionIDForOrder = pm.openPositions[order.Symbol].ID
 		}
 	} else {
 		// SELL order
@@ -199,6 +209,7 @@ func (pm *PositionManager) OnOrderFilled(ctx context.Context, order *Order, fill
 						if err != nil {
 							return err
 						}
+						positionIDForOrder = pm.openPositions[order.Symbol].ID
 					}
 				} else {
 					// Partially closing LONG position
@@ -220,6 +231,23 @@ func (pm *PositionManager) OnOrderFilled(ctx context.Context, order *Order, fill
 			if err != nil {
 				return err
 			}
+			positionIDForOrder = pm.openPositions[order.Symbol].ID
+		}
+	}
+
+	// Link the order to the position it created/affected so
+	// orders.position_id FK is populated and joins work (DB-004 / #128).
+	if pm.db != nil && positionIDForOrder != uuid.Nil {
+		orderID, parseErr := uuid.Parse(order.ID)
+		if parseErr != nil {
+			log.Warn().Err(parseErr).Str("order_id", order.ID).Msg("Cannot link order to position: invalid order UUID")
+		} else if err := pm.db.UpdateOrderPositionID(ctx, orderID, positionIDForOrder); err != nil {
+			log.Error().Err(err).
+				Str("order_id", order.ID).
+				Str("position_id", positionIDForOrder.String()).
+				Msg("Failed to link order to position")
+			// Non-fatal: the position operation succeeded; a missing FK is
+			// a data-quality issue but shouldn't fail the fill processing.
 		}
 	}
 

--- a/internal/exchange/position_manager_test.go
+++ b/internal/exchange/position_manager_test.go
@@ -353,3 +353,89 @@ func TestGetOpenPositions(t *testing.T) {
 	positions := pm.GetOpenPositions()
 	assert.Equal(t, 2, len(positions))
 }
+
+// TestOnOrderFilled_LinksOrderToPosition exercises the order→position FK
+// linking code path added for DB-004 (#128). With a nil DB the actual
+// UpdateOrderPositionID call is skipped, but we verify that:
+// (a) OnOrderFilled doesn't panic,
+// (b) the position is created and tracked in memory, and
+// (c) the position ID is non-nil so the linking branch would fire with a real DB.
+func TestOnOrderFilled_LinksOrderToPosition(t *testing.T) {
+	t.Run("BUY opens new LONG", func(t *testing.T) {
+		pm := NewPositionManager(nil) // nil DB — linking is skipped, no panic
+		sessionID := uuid.New()
+		pm.SetSession(&sessionID)
+
+		order := &Order{
+			ID:       uuid.New().String(),
+			Symbol:   "BTC/USD",
+			Side:     OrderSideBuy,
+			Quantity: 1.0,
+		}
+		fills := []Fill{{Price: 50000.0, Quantity: 1.0, Timestamp: time.Now()}}
+
+		err := pm.OnOrderFilled(t.Context(), order, fills)
+		require.NoError(t, err)
+
+		pos, exists := pm.GetPosition("BTC/USD")
+		require.True(t, exists, "position should be created")
+		assert.Equal(t, db.PositionSideLong, pos.Side)
+		assert.NotEqual(t, uuid.Nil, pos.ID, "position ID should be set for FK linking")
+	})
+
+	t.Run("SELL opens new SHORT", func(t *testing.T) {
+		pm := NewPositionManager(nil)
+		sessionID := uuid.New()
+		pm.SetSession(&sessionID)
+
+		order := &Order{
+			ID:       uuid.New().String(),
+			Symbol:   "ETH/USD",
+			Side:     OrderSideSell,
+			Quantity: 2.0,
+		}
+		fills := []Fill{{Price: 3000.0, Quantity: 2.0, Timestamp: time.Now()}}
+
+		err := pm.OnOrderFilled(t.Context(), order, fills)
+		require.NoError(t, err)
+
+		pos, exists := pm.GetPosition("ETH/USD")
+		require.True(t, exists, "position should be created")
+		assert.Equal(t, db.PositionSideShort, pos.Side)
+		assert.NotEqual(t, uuid.Nil, pos.ID)
+	})
+
+	t.Run("BUY fully closes SHORT and opens LONG remainder", func(t *testing.T) {
+		pm := NewPositionManager(nil)
+		sessionID := uuid.New()
+		pm.SetSession(&sessionID)
+
+		// Pre-existing SHORT
+		pm.openPositions["BTC/USD"] = &db.Position{
+			ID:         uuid.New(),
+			SessionID:  &sessionID,
+			Symbol:     "BTC/USD",
+			Side:       db.PositionSideShort,
+			EntryPrice: 50000.0,
+			Quantity:   1.0,
+			EntryTime:  time.Now(),
+		}
+
+		order := &Order{
+			ID:       uuid.New().String(),
+			Symbol:   "BTC/USD",
+			Side:     OrderSideBuy,
+			Quantity: 3.0, // 1 to close SHORT + 2 remainder opens LONG
+		}
+		fills := []Fill{{Price: 49000.0, Quantity: 3.0, Timestamp: time.Now()}}
+
+		err := pm.OnOrderFilled(t.Context(), order, fills)
+		require.NoError(t, err)
+
+		pos, exists := pm.GetPosition("BTC/USD")
+		require.True(t, exists, "remainder LONG should exist")
+		assert.Equal(t, db.PositionSideLong, pos.Side)
+		assert.InDelta(t, 2.0, pos.Quantity, 0.001)
+		assert.NotEqual(t, uuid.Nil, pos.ID, "new LONG position should have an ID for FK linking")
+	})
+}


### PR DESCRIPTION
## Summary

Fourth pass at the 2026-03-25 audit backlog. Triaged 6 DB-layer issues (#126-131); 5 were stale, 1 genuinely broken.

### Fix: DB-004 (#128) — orders.position_id never populated

\`UpdateOrderPositionIDTx\` was defined in \`internal/db/orders.go\` but never called from any code path. Every order had \`position_id = NULL\`, breaking all \`orders JOIN positions\` queries.

**Changes:**
- **\`internal/db/orders.go\`**: Added \`UpdateOrderPositionID\` (non-Tx variant using the pool) for code paths without an active transaction.
- **\`internal/exchange/position_manager.go\`**: \`OnOrderFilled\` now captures the relevant position ID through each branch and calls \`UpdateOrderPositionID\` at the end of fill processing. The link is non-fatal — if the DB update fails, the fill itself still succeeds and a warning is logged, since a missing FK is a data-quality issue not a trading-correctness issue.

Position ID resolution per branch:
| Branch | Position ID source |
|--------|-------------------|
| Open new position | \`pm.openPositions[symbol].ID\` (just created) |
| Average into existing | \`existingPos.ID\` (captured before operations) |
| Full close | \`existingPos.ID\` (captured before close deletes from map) |
| Full close + open remainder | New position's ID from \`pm.openPositions[symbol].ID\` |
| Partial close | \`existingPos.ID\` (parent position remains) |

### Closed as stale (5)

| # | Reason |
|---|---|
| #127 DB-003 | No \`metrics_updater\` file exists in Go source — code was removed |
| #126 DB-002 | Same — no \`metrics_updater\` file |
| #129 DB-005 | Positions use \`EntryPrice\` (set on open, weighted-avg on add); \`average_price\` only exists on \`Order\` and is documented as in-memory-only |
| #131 DB-007 | Migration \`022_data_integrity_fixes.sql\` already adds \`session_id\` to trades with FK + index |
| #130 DB-006 | \`StopSession\` writes \`final_capital = $1\`; all 4 callers pass a value |

## Test Plan
- [x] \`go build ./...\` — clean
- [x] \`go test -race ./internal/exchange/...\` — pass
- [x] \`go test -race -short ./internal/db/...\` — pass
- [ ] Manual: place a paper trade via API, verify \`SELECT position_id FROM orders WHERE id = '<order_id>'\` is no longer NULL

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)