### PR TITLE
fix(security): close auth gaps + HTTPS bypass (#118, #146, #147)

### DIFF
--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -157,26 +157,38 @@ func (s *APIServer) setupRoutes() {
 		// WebSocket endpoint (no rate limiting - uses connection limits)
 		v1.GET("/ws", s.handleWebSocket)
 
-		// Agent routes (read-only, apply read rate limiter)
+		// Agent routes (read-only, apply read rate limiter + auth)
+		// QA-003 (#146): all read-only trading data endpoints now require
+		// authentication when enabled, closing the asymmetric trust boundary
+		// where /sessions and /positions were public but /orders was gated.
 		agents := v1.Group("/agents")
 		agents.Use(s.rateLimiter.ReadMiddleware())
+		if s.config.API.Auth.Enabled {
+			agents.Use(api.AuthMiddleware(s.apiKeyStore, authConfig))
+		}
 		{
 			agents.GET("", s.handleListAgents)
 			agents.GET("/:name", s.handleGetAgent)
 			agents.GET("/:name/status", s.handleGetAgentStatus)
 		}
 
-		// Session routes (read-only, apply read rate limiter)
+		// Session routes (read-only, apply read rate limiter + auth)
 		sessions := v1.Group("/sessions")
 		sessions.Use(s.rateLimiter.ReadMiddleware())
+		if s.config.API.Auth.Enabled {
+			sessions.Use(api.AuthMiddleware(s.apiKeyStore, authConfig))
+		}
 		{
 			sessions.GET("", s.handleListSessions)
 			sessions.GET("/:id", s.handleGetSession)
 		}
 
-		// Position routes (read-only, apply read rate limiter)
+		// Position routes (read-only, apply read rate limiter + auth)
 		positions := v1.Group("/positions")
 		positions.Use(s.rateLimiter.ReadMiddleware())
+		if s.config.API.Auth.Enabled {
+			positions.Use(api.AuthMiddleware(s.apiKeyStore, authConfig))
+		}
 		{
 			positions.GET("", s.handleListPositions)
 			positions.GET("/:symbol", s.handleGetPosition)
@@ -251,14 +263,19 @@ func (s *APIServer) setupRoutes() {
 		backtestHandler := api.NewBacktestHandler(s.db.Pool())
 		backtestHandler.RegisterRoutesWithRateLimiter(v1, s.rateLimiter.ReadMiddleware(), s.rateLimiter.OrderMiddleware())
 
-		// Dashboard routes (TC-002) with rate limiting
-		// Provides user dashboard with trading control, positions, P&L, and system status
-		// Use an HTTP client to the orchestrator so the dashboard can report agent counts
-		// even though the API and orchestrator run as separate processes.
+		// Dashboard routes (TC-002) with rate limiting + auth
+		// QA-004 (#147): dashboard exposes positions, PnL, and trading controls
+		// — all require authentication when enabled. Auth is applied at the
+		// group level so it runs before the rate limiters (unauthenticated
+		// requests are rejected before consuming rate-limit budget).
 		orchestratorURL := s.getOrchestratorURL()
 		orchClient := api.NewOrchestratorClient(orchestratorURL)
 		dashboardHandler := api.NewDashboardHandlerWithOrchestrator(s.db, orchClient, config.Version)
-		dashboardHandler.RegisterRoutesWithRateLimiter(v1, s.rateLimiter.ReadMiddleware(), s.rateLimiter.ControlMiddleware())
+		dashboardGroup := v1.Group("")
+		if s.config.API.Auth.Enabled {
+			dashboardGroup.Use(api.AuthMiddleware(s.apiKeyStore, authConfig))
+		}
+		dashboardHandler.RegisterRoutesWithRateLimiter(dashboardGroup, s.rateLimiter.ReadMiddleware(), s.rateLimiter.ControlMiddleware())
 
 		// Trades routes — fill records from the trades table
 		tradesHandler := api.NewTradesHandler(s.db)

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -157,38 +157,40 @@ func (s *APIServer) setupRoutes() {
 		// WebSocket endpoint (no rate limiting - uses connection limits)
 		v1.GET("/ws", s.handleWebSocket)
 
-		// Agent routes (read-only, apply read rate limiter + auth)
+		// Agent routes (read-only, auth then rate limiter)
 		// QA-003 (#146): all read-only trading data endpoints now require
 		// authentication when enabled, closing the asymmetric trust boundary
 		// where /sessions and /positions were public but /orders was gated.
+		// Auth runs before the rate limiter so unauthenticated requests are
+		// rejected before consuming rate-limit budget.
 		agents := v1.Group("/agents")
-		agents.Use(s.rateLimiter.ReadMiddleware())
 		if s.config.API.Auth.Enabled {
 			agents.Use(api.AuthMiddleware(s.apiKeyStore, authConfig))
 		}
+		agents.Use(s.rateLimiter.ReadMiddleware())
 		{
 			agents.GET("", s.handleListAgents)
 			agents.GET("/:name", s.handleGetAgent)
 			agents.GET("/:name/status", s.handleGetAgentStatus)
 		}
 
-		// Session routes (read-only, apply read rate limiter + auth)
+		// Session routes (read-only, auth then rate limiter)
 		sessions := v1.Group("/sessions")
-		sessions.Use(s.rateLimiter.ReadMiddleware())
 		if s.config.API.Auth.Enabled {
 			sessions.Use(api.AuthMiddleware(s.apiKeyStore, authConfig))
 		}
+		sessions.Use(s.rateLimiter.ReadMiddleware())
 		{
 			sessions.GET("", s.handleListSessions)
 			sessions.GET("/:id", s.handleGetSession)
 		}
 
-		// Position routes (read-only, apply read rate limiter + auth)
+		// Position routes (read-only, auth then rate limiter)
 		positions := v1.Group("/positions")
-		positions.Use(s.rateLimiter.ReadMiddleware())
 		if s.config.API.Auth.Enabled {
 			positions.Use(api.AuthMiddleware(s.apiKeyStore, authConfig))
 		}
+		positions.Use(s.rateLimiter.ReadMiddleware())
 		{
 			positions.GET("", s.handleListPositions)
 			positions.GET("/:symbol", s.handleGetPosition)
@@ -271,6 +273,9 @@ func (s *APIServer) setupRoutes() {
 		orchestratorURL := s.getOrchestratorURL()
 		orchClient := api.NewOrchestratorClient(orchestratorURL)
 		dashboardHandler := api.NewDashboardHandlerWithOrchestrator(s.db, orchClient, config.Version)
+		// Empty-string group inherits v1's path prefix; it only scopes the
+		// middleware (auth) to the routes that RegisterRoutesWithRateLimiter
+		// mounts inside it (/dashboard/*), not to all of /api/v1.
 		dashboardGroup := v1.Group("")
 		if s.config.API.Auth.Enabled {
 			dashboardGroup.Use(api.AuthMiddleware(s.apiKeyStore, authConfig))

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -260,7 +260,10 @@ api:
   auth:
     enabled: true                # Set to false only in local development
     header_name: "X-API-Key"     # Header name for API key (also supports Authorization: Bearer <key>)
-    require_https: true          # Require HTTPS in production (localhost/127.0.0.1 are exempt)
+    require_https: true              # Require HTTPS in production (localhost/127.0.0.1/[::1] are exempt)
+    trust_forwarded_proto: false     # Set true only behind a trusted reverse proxy (K8s ingress, ALB)
+                                     # that strips and re-sets X-Forwarded-Proto. When false (default),
+                                     # the header is ignored to prevent bypass over plain HTTP.
 
   # CORS Configuration
   # Controls which origins can access the API from browsers

--- a/internal/api/auth_middleware.go
+++ b/internal/api/auth_middleware.go
@@ -63,9 +63,10 @@ type APIKey struct {
 
 // AuthConfig contains authentication configuration
 type AuthConfig struct {
-	Enabled      bool   `mapstructure:"enabled"`
-	HeaderName   string `mapstructure:"header_name"`   // Default: "X-API-Key" or "Authorization"
-	RequireHTTPS bool   `mapstructure:"require_https"` // Require HTTPS in production
+	Enabled             bool   `mapstructure:"enabled"`
+	HeaderName          string `mapstructure:"header_name"`           // Default: "X-API-Key" or "Authorization"
+	RequireHTTPS        bool   `mapstructure:"require_https"`         // Require HTTPS in production
+	TrustForwardedProto bool   `mapstructure:"trust_forwarded_proto"` // Trust X-Forwarded-Proto from reverse proxy (default false)
 }
 
 // DefaultAuthConfig returns the default auth configuration
@@ -191,11 +192,16 @@ func AuthMiddleware(store *APIKeyStore, config *AuthConfig) gin.HandlerFunc {
 			return
 		}
 
-		// Check HTTPS requirement in production
-		if config.RequireHTTPS && c.Request.TLS == nil && c.GetHeader("X-Forwarded-Proto") != "https" {
-			// Allow localhost for development
+		// Check HTTPS requirement in production.
+		// Only trust X-Forwarded-Proto when TrustForwardedProto is explicitly
+		// enabled (e.g. behind a K8s ingress or ALB that terminates TLS).
+		// Without that flag the header is user-spoofable over plain HTTP and
+		// bypasses the check entirely (SEC-004 / #118).
+		if config.RequireHTTPS && c.Request.TLS == nil {
+			forwardedHTTPS := config.TrustForwardedProto && c.GetHeader("X-Forwarded-Proto") == "https"
 			host := c.Request.Host
-			if !strings.HasPrefix(host, "localhost") && !strings.HasPrefix(host, "127.0.0.1") {
+			isLocalhost := strings.HasPrefix(host, "localhost") || strings.HasPrefix(host, "127.0.0.1")
+			if !forwardedHTTPS && !isLocalhost {
 				log.Warn().
 					Str("host", host).
 					Str("ip", c.ClientIP()).

--- a/internal/api/auth_middleware.go
+++ b/internal/api/auth_middleware.go
@@ -72,9 +72,10 @@ type AuthConfig struct {
 // DefaultAuthConfig returns the default auth configuration
 func DefaultAuthConfig() *AuthConfig {
 	return &AuthConfig{
-		Enabled:      false, // Disabled by default for development
-		HeaderName:   "X-API-Key",
-		RequireHTTPS: true,
+		Enabled:             false, // Disabled by default for development
+		HeaderName:          "X-API-Key",
+		RequireHTTPS:        true,
+		TrustForwardedProto: false, // Only enable behind a trusted reverse proxy (K8s ingress, ALB)
 	}
 }
 
@@ -200,7 +201,7 @@ func AuthMiddleware(store *APIKeyStore, config *AuthConfig) gin.HandlerFunc {
 		if config.RequireHTTPS && c.Request.TLS == nil {
 			forwardedHTTPS := config.TrustForwardedProto && c.GetHeader("X-Forwarded-Proto") == "https"
 			host := c.Request.Host
-			isLocalhost := strings.HasPrefix(host, "localhost") || strings.HasPrefix(host, "127.0.0.1")
+			isLocalhost := strings.HasPrefix(host, "localhost") || strings.HasPrefix(host, "127.0.0.1") || strings.HasPrefix(host, "[::1]")
 			if !forwardedHTTPS && !isLocalhost {
 				log.Warn().
 					Str("host", host).

--- a/internal/api/auth_middleware_test.go
+++ b/internal/api/auth_middleware_test.go
@@ -65,6 +65,95 @@ func TestDefaultAuthConfig(t *testing.T) {
 	assert.False(t, config.Enabled)
 	assert.Equal(t, "X-API-Key", config.HeaderName)
 	assert.True(t, config.RequireHTTPS)
+	assert.False(t, config.TrustForwardedProto)
+}
+
+// TestTrustForwardedProto_SEC004 verifies that the X-Forwarded-Proto header
+// is only trusted when TrustForwardedProto is explicitly enabled, preventing
+// the HTTPS bypass described in SEC-004 / #118.
+func TestTrustForwardedProto_SEC004(t *testing.T) {
+	// The HTTPS enforcement check runs BEFORE key validation in the
+	// middleware, so we can use a nil-DB store — the test either gets 403
+	// (HTTPS blocked) or proceeds past the HTTPS gate to key validation
+	// (which returns 401 because there's no DB). Status != 403 proves
+	// the HTTPS check passed.
+	store := NewAPIKeyStore(nil, true)
+
+	okHandler := func(c *gin.Context) { c.String(http.StatusOK, "ok") }
+
+	t.Run("spoofed_header_blocked_when_trust_disabled", func(t *testing.T) {
+		config := &AuthConfig{
+			Enabled:             true,
+			HeaderName:          "X-API-Key",
+			RequireHTTPS:        true,
+			TrustForwardedProto: false,
+		}
+
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		router.Use(AuthMiddleware(store, config))
+		router.GET("/secure", okHandler)
+
+		req := httptest.NewRequest(http.MethodGet, "/secure", nil)
+		req.Header.Set("X-API-Key", "any-key")
+		req.Header.Set("X-Forwarded-Proto", "https")
+		req.Host = "api.example.com"
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code,
+			"spoofed X-Forwarded-Proto should be rejected when TrustForwardedProto=false")
+	})
+
+	t.Run("forwarded_proto_trusted_when_enabled", func(t *testing.T) {
+		config := &AuthConfig{
+			Enabled:             true,
+			HeaderName:          "X-API-Key",
+			RequireHTTPS:        true,
+			TrustForwardedProto: true,
+		}
+
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		router.Use(AuthMiddleware(store, config))
+		router.GET("/secure", okHandler)
+
+		req := httptest.NewRequest(http.MethodGet, "/secure", nil)
+		req.Header.Set("X-API-Key", "any-key")
+		req.Header.Set("X-Forwarded-Proto", "https")
+		req.Host = "api.example.com"
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.NotEqual(t, http.StatusForbidden, w.Code,
+			"X-Forwarded-Proto: https should be trusted when TrustForwardedProto=true (expect 401 from key validation, not 403)")
+	})
+
+	t.Run("ipv6_loopback_allowed", func(t *testing.T) {
+		config := &AuthConfig{
+			Enabled:             true,
+			HeaderName:          "X-API-Key",
+			RequireHTTPS:        true,
+			TrustForwardedProto: false,
+		}
+
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		router.Use(AuthMiddleware(store, config))
+		router.GET("/secure", okHandler)
+
+		req := httptest.NewRequest(http.MethodGet, "/secure", nil)
+		req.Header.Set("X-API-Key", "any-key")
+		req.Host = "[::1]:8080"
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.NotEqual(t, http.StatusForbidden, w.Code,
+			"IPv6 loopback should be allowed even without HTTPS (expect 401, not 403)")
+	})
 }
 
 // =============================================================================

--- a/internal/orchestrator/orchestrator_integration_test.go
+++ b/internal/orchestrator/orchestrator_integration_test.go
@@ -139,17 +139,26 @@ func TestIntegration_MultiAgentCoordination(t *testing.T) {
 
 	// Test Case 2: Split vote with risk veto
 	t.Run("risk_agent_veto", func(t *testing.T) {
-		// Drain any stale BTC/USDT decisions left over from the previous subtest.
-		// BTC/USDT signals remain valid for MaxSignalAge (5 min), so the orchestrator
-		// may keep generating decisions for them; we must skip those here.
-	drainLoop:
-		for {
-			select {
-			case <-decisionChan:
-			default:
-				break drainLoop
-			}
+		drainDecisions(decisionChan)
+
+		// Re-send heartbeats so the orchestrator still considers these agents
+		// active. Under -race on CI, enough wall time may have elapsed between
+		// test case 1 and test case 2 that the health checker marks them stale.
+		vetoAgents := []struct {
+			name   string
+			typ    string
+			weight float64
+		}{
+			{"technical-agent", "analysis", 0.25},
+			{"orderbook-agent", "analysis", 0.20},
+			{"trend-agent", "strategy", 0.30},
+			{"arbitrage-agent", "strategy", 0.20},
+			{"risk-agent", "risk", 1.00},
 		}
+		for _, a := range vetoAgents {
+			sendHeartbeat(t, nc, config.HeartbeatTopic, a.name, a.typ, a.weight)
+		}
+		time.Sleep(200 * time.Millisecond)
 
 		// 4 agents vote BUY
 		buyAgents := []string{"technical-agent", "orderbook-agent", "trend-agent", "arbitrage-agent"}
@@ -204,6 +213,10 @@ func TestIntegration_MultiAgentCoordination(t *testing.T) {
 
 	// Test Case 3: Low confidence - should result in HOLD
 	t.Run("low_confidence_hold", func(t *testing.T) {
+		// Drain stale decisions from earlier subtests (BTC/USDT, ETH/USDT)
+		// so we don't pick them up below.
+		drainDecisions(decisionChan)
+
 		// Register agents with heartbeats first
 		agents := []struct {
 			name   string
@@ -219,7 +232,9 @@ func TestIntegration_MultiAgentCoordination(t *testing.T) {
 			sendHeartbeat(t, nc, config.HeartbeatTopic, agent.name, agent.typ, agent.weight)
 		}
 
-		time.Sleep(200 * time.Millisecond)
+		// Give the orchestrator enough time to process heartbeats and register
+		// the new agents. 200ms was too tight under -race on CI runners.
+		time.Sleep(500 * time.Millisecond)
 
 		// All agents vote with low confidence
 		for _, agent := range agents {
@@ -235,13 +250,21 @@ func TestIntegration_MultiAgentCoordination(t *testing.T) {
 			sendSignal(t, nc, config.SignalTopic, signal)
 		}
 
-		// Wait for decision
-		select {
-		case decision := <-decisionChan:
-			assert.Equal(t, orchestrator.SignalActionHold, decision.Action)
-			assert.Less(t, decision.Confidence, config.MinConfidence)
-		case <-time.After(5 * time.Second):
-			t.Fatal("Timeout waiting for decision")
+		// Wait for a SOL/USDT decision. Earlier subtests may still produce
+		// BTC/USDT or ETH/USDT decisions from stale signals — skip those.
+		deadline := time.After(15 * time.Second)
+		for {
+			select {
+			case decision := <-decisionChan:
+				if decision.Symbol != "SOL/USDT" {
+					continue // skip stale decisions from earlier subtests
+				}
+				assert.Equal(t, orchestrator.SignalActionHold, decision.Action)
+				assert.Less(t, decision.Confidence, config.MinConfidence)
+				return
+			case <-deadline:
+				t.Fatal("Timeout waiting for SOL/USDT decision")
+			}
 		}
 	})
 
@@ -257,11 +280,7 @@ func TestIntegration_MultiAgentCoordination(t *testing.T) {
 			t.Skip("skipping flaky split_vote_no_consensus under CI; run locally with -tags=integration")
 		}
 
-		// Drain any leftover decisions from previous subtests to avoid a stale
-		// decision being picked up by this subtest's select.
-		for len(decisionChan) > 0 {
-			<-decisionChan
-		}
+		drainDecisions(decisionChan)
 
 		// Half vote BUY, half vote SELL
 		buyAgents := []string{"technical-agent", "trend-agent"}
@@ -519,6 +538,10 @@ func sendHeartbeat(t *testing.T, nc *nats.Conn, topic, agentName, agentType stri
 	require.NoError(t, err)
 	err = nc.Publish(topic, data)
 	require.NoError(t, err)
+	// Flush so the embedded NATS server delivers the heartbeat before the
+	// orchestrator's next tick. Without this, buffered publishes can race
+	// the 1s StepInterval under -race on slow CI runners.
+	require.NoError(t, nc.Flush())
 }
 
 func sendSignal(t *testing.T, nc *nats.Conn, topic string, signal *orchestrator.AgentSignal) {
@@ -527,4 +550,18 @@ func sendSignal(t *testing.T, nc *nats.Conn, topic string, signal *orchestrator.
 	require.NoError(t, err)
 	err = nc.Publish(topic, data)
 	require.NoError(t, err)
+	require.NoError(t, nc.Flush())
+}
+
+// drainDecisions empties the decision channel of any stale decisions from
+// earlier subtests. Call this at the start of each subtest that reads from
+// decisionChan to avoid picking up decisions for symbols from a prior case.
+func drainDecisions(ch <-chan *orchestrator.TradingDecision) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Fifth wave of 2026-03-25 audit triage. Audited 5 security issues; 2 stale, 3 real.

### Fixes

**SEC-004 (#118) -- HTTPS enforcement bypass via X-Forwarded-Proto**

The RequireHTTPS check trusted X-Forwarded-Proto unconditionally. An attacker over plain HTTP could send the header to bypass the check. Now the header is only trusted when TrustForwardedProto is explicitly set in AuthConfig (for reverse-proxy deployments). Default is false, matching the SetTrustedProxies([]string{}) setup in main.go.

**QA-003 (#146) -- Asymmetric auth on read-only endpoints**

/agents, /sessions, and /positions were public while /orders required auth. All three groups now require auth when enabled, closing the inconsistent trust boundary.

**QA-004 (#147) -- Dashboard without auth**

/dashboard exposed positions, PnL, and trading controls without auth. Auth middleware now applied at the group level before rate limiters so unauthenticated requests are rejected before consuming rate-limit budget.

### Closed as stale (2)

- #145 QA-002: X-API-Key already in CORS AllowHeaders
- #117 SEC-003: SetTrustedProxies([]string{}) ignores X-Forwarded-For

## Test plan
- [x] go build ./... clean
- [x] go test -race ./internal/api/... ./cmd/api/... pass
- [ ] Manual: with auth enabled, verify /api/v1/sessions returns 401 without X-API-Key
- [ ] Manual: verify X-Forwarded-Proto: https over plain HTTP no longer bypasses RequireHTTPS

Closes #118, #146, #147.

Generated with Claude Code