### PR TITLE
fix(db): persist Fees on CreatePosition + fix bulk-pnl test fixture

### DIFF
--- a/internal/db/order_position_helpers_integration_test.go
+++ b/internal/db/order_position_helpers_integration_test.go
@@ -504,8 +504,11 @@ func TestPositionHelperMethodsWithTestcontainers(t *testing.T) {
 			Quantity:   100.0,
 			EntryPrice: 20.0,
 			EntryTime:  time.Now(),
-			// Fees defaults to 0 here (not set on the struct), so the
-			// existing assertions on accumulated fees still hold.
+			// Fees is 0 because this fixture intentionally does not set
+			// it on the struct. The post-#217 INSERT now persists that
+			// 0 to the DB explicitly (rather than relying on the column
+			// default that the old buggy path leaned on), so the
+			// downstream "0 + N" accumulation assertion still holds.
 		}
 		err := tc.DB.CreatePosition(ctx, pos)
 		require.NoError(t, err)
@@ -535,8 +538,11 @@ func TestPositionHelperMethodsWithTestcontainers(t *testing.T) {
 			Quantity:   50.0,
 			EntryPrice: 10.0,
 			EntryTime:  time.Now(),
-			// Fees defaults to 0 here (not set on the struct), so the
-			// existing assertions on accumulated fees still hold.
+			// Fees is 0 because this fixture intentionally does not set
+			// it on the struct. The post-#217 INSERT now persists that
+			// 0 to the DB explicitly (rather than relying on the column
+			// default that the old buggy path leaned on), so the
+			// downstream "0 + N" accumulation assertion still holds.
 		}
 		err := tc.DB.CreatePosition(ctx, pos)
 		require.NoError(t, err)

--- a/internal/db/order_position_helpers_integration_test.go
+++ b/internal/db/order_position_helpers_integration_test.go
@@ -504,7 +504,8 @@ func TestPositionHelperMethodsWithTestcontainers(t *testing.T) {
 			Quantity:   100.0,
 			EntryPrice: 20.0,
 			EntryTime:  time.Now(),
-			// Note: Fees field is not inserted by CreatePosition, defaults to 0
+			// Fees defaults to 0 here (not set on the struct), so the
+			// existing assertions on accumulated fees still hold.
 		}
 		err := tc.DB.CreatePosition(ctx, pos)
 		require.NoError(t, err)
@@ -534,7 +535,8 @@ func TestPositionHelperMethodsWithTestcontainers(t *testing.T) {
 			Quantity:   50.0,
 			EntryPrice: 10.0,
 			EntryTime:  time.Now(),
-			// Note: Fees field is not inserted by CreatePosition, defaults to 0
+			// Fees defaults to 0 here (not set on the struct), so the
+			// existing assertions on accumulated fees still hold.
 		}
 		err := tc.DB.CreatePosition(ctx, pos)
 		require.NoError(t, err)

--- a/internal/db/positions.go
+++ b/internal/db/positions.go
@@ -755,9 +755,17 @@ func (db *DB) UpdatePositionQuantity(ctx context.Context, id uuid.UUID, newQuant
 // CreatePositionTx inserts a new position into the database within an existing transaction.
 func (db *DB) CreatePositionTx(ctx context.Context, tx pgx.Tx, position *Position) error {
 	// Mirror CreatePosition: include `fees` in the INSERT so the
-	// entry-side fee is preserved. ClosePosition's accumulator
-	// (`fees = fees + $4`) depends on this row starting at the
-	// entry-side fee, not 0.
+	// entry-side fee is preserved. The two close paths consume this
+	// stored fee differently:
+	//   - ClosePosition (non-Tx) accumulates `fees = fees + $4`, so
+	//     the row MUST start at the entry-side fee for the closed
+	//     record to reflect entry+exit total.
+	//   - ClosePositionTx SETs `fees = $5` directly with a
+	//     caller-computed total (see the comment at the
+	//     ClosePositionTx call site for the reasoning), so the
+	//     stored entry fee is overwritten on close.
+	// Either way, the row is wrong if we drop the entry fee at
+	// CreatePosition time, so the column belongs in the INSERT.
 	query := `
 		INSERT INTO positions (
 			id, session_id, symbol, exchange, side, entry_price, quantity,

--- a/internal/db/positions.go
+++ b/internal/db/positions.go
@@ -260,6 +260,19 @@ func (db *DB) GetOpenPositions(ctx context.Context, sessionID uuid.UUID) ([]*Pos
 // The WHERE clause includes exit_time IS NULL so a double-close attempt
 // returns rowsAffected=0 and is rejected, preserving the original
 // "already closed" semantics in one round-trip instead of two.
+//
+// Fee semantics — IMPORTANT contrast with ClosePositionTx:
+//   - ClosePosition (this function) ACCUMULATES via `fees = fees + $4`,
+//     so the row must already carry the entry-side fee at close time.
+//   - ClosePositionTx OVERWRITES via `fees = $5` with a caller-computed
+//     entry+exit total.
+//   - realized_pnl in ClosePosition deducts only the close-side fee
+//     ($4); ClosePositionTx deducts the full caller-computed total.
+//
+// Both are correct individually but produce slightly different
+// realized_pnl on the same trade (ClosePosition's value is overstated
+// by the entry fee). Tracked for unification in #218 — DO NOT change
+// one path without the other.
 func (db *DB) ClosePosition(ctx context.Context, id uuid.UUID, exitPrice float64, exitReason string, fees float64) error {
 	now := time.Now()
 	// Query parameters:

--- a/internal/db/positions.go
+++ b/internal/db/positions.go
@@ -54,14 +54,22 @@ type Position struct {
 	UpdatedAt     time.Time    `db:"updated_at"`
 }
 
-// CreatePosition inserts a new position into the database
+// CreatePosition inserts a new position into the database.
+//
+// The `fees` column is included in the INSERT so the entry-side fee
+// the caller already paid (commission, slippage, exchange fee) is
+// preserved on the row. Without this, ClosePosition's
+// `fees = fees + $4` accumulator starts from 0 instead of the entry
+// fee and the closed-position record under-reports total trading
+// cost — bug observed in TestClosePosition where fees of 1.0 + 0.5
+// resolved to 0.5 instead of 1.5.
 func (db *DB) CreatePosition(ctx context.Context, position *Position) error {
 	query := `
 		INSERT INTO positions (
 			id, session_id, symbol, exchange, side, entry_price, quantity,
-			entry_time, stop_loss, take_profit, entry_reason, metadata, created_at, updated_at
+			entry_time, stop_loss, take_profit, fees, entry_reason, metadata, created_at, updated_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
 		)
 	`
 
@@ -86,6 +94,7 @@ func (db *DB) CreatePosition(ctx context.Context, position *Position) error {
 		position.EntryTime,
 		position.StopLoss,
 		position.TakeProfit,
+		position.Fees,
 		position.EntryReason,
 		position.Metadata,
 		position.CreatedAt,
@@ -745,12 +754,16 @@ func (db *DB) UpdatePositionQuantity(ctx context.Context, id uuid.UUID, newQuant
 
 // CreatePositionTx inserts a new position into the database within an existing transaction.
 func (db *DB) CreatePositionTx(ctx context.Context, tx pgx.Tx, position *Position) error {
+	// Mirror CreatePosition: include `fees` in the INSERT so the
+	// entry-side fee is preserved. ClosePosition's accumulator
+	// (`fees = fees + $4`) depends on this row starting at the
+	// entry-side fee, not 0.
 	query := `
 		INSERT INTO positions (
 			id, session_id, symbol, exchange, side, entry_price, quantity,
-			entry_time, stop_loss, take_profit, entry_reason, metadata, created_at, updated_at
+			entry_time, stop_loss, take_profit, fees, entry_reason, metadata, created_at, updated_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
 		)
 	`
 
@@ -775,6 +788,7 @@ func (db *DB) CreatePositionTx(ctx context.Context, tx pgx.Tx, position *Positio
 		position.EntryTime,
 		position.StopLoss,
 		position.TakeProfit,
+		position.Fees,
 		position.EntryReason,
 		position.Metadata,
 		position.CreatedAt,

--- a/internal/db/positions_bulk_pnl_integration_test.go
+++ b/internal/db/positions_bulk_pnl_integration_test.go
@@ -54,13 +54,21 @@ func TestBulkUpdateUnrealizedPnL(t *testing.T) {
 	})
 
 	t.Run("updates multiple open positions in one round-trip", func(t *testing.T) {
-		// Create three open positions
-		positions := make([]*db.Position, 3)
-		for i := range positions {
+		// Create three open positions on DISTINCT symbols. The unique
+		// partial index `idx_positions_open_session_symbol_uniq`
+		// (migration 019) forbids two OPEN rows with the same
+		// (session_id, symbol) — a single trader can hold at most one
+		// open position per pair per session — so the previous
+		// hardcoded "BTC/USDT" loop violated the constraint on the
+		// second insert. Three different symbols still exercise the
+		// bulk update path while satisfying the uniqueness invariant.
+		symbols := []string{"BTC/USDT", "ETH/USDT", "SOL/USDT"}
+		positions := make([]*db.Position, len(symbols))
+		for i, sym := range symbols {
 			positions[i] = &db.Position{
 				ID:         uuid.New(),
 				SessionID:  &session.ID,
-				Symbol:     "BTC/USDT",
+				Symbol:     sym,
 				Exchange:   "binance",
 				Side:       db.PositionSideLong,
 				EntryPrice: 50000.0,

--- a/internal/db/positions_bulk_pnl_integration_test.go
+++ b/internal/db/positions_bulk_pnl_integration_test.go
@@ -96,10 +96,12 @@ func TestBulkUpdateUnrealizedPnL(t *testing.T) {
 
 	t.Run("closed positions are skipped", func(t *testing.T) {
 		// Open + close a position with unrealized_pnl=0 (from ClosePosition).
+		// Use AVAX/USDT to avoid colliding with the ETH/USDT open
+		// position left by the "updates multiple..." subtest above.
 		pos := &db.Position{
 			ID:         uuid.New(),
 			SessionID:  &session.ID,
-			Symbol:     "ETH/USDT",
+			Symbol:     "AVAX/USDT",
 			Exchange:   "binance",
 			Side:       db.PositionSideLong,
 			EntryPrice: 3000.0,
@@ -124,11 +126,13 @@ func TestBulkUpdateUnrealizedPnL(t *testing.T) {
 	})
 
 	t.Run("unknown IDs are silently skipped", func(t *testing.T) {
-		// Mix one real open position with an ID that doesn't exist in the DB.
+		// Mix one real open position with an ID that doesn't exist in
+		// the DB. Use DOT/USDT to avoid colliding with SOL/USDT left
+		// open by the "updates multiple..." subtest above.
 		pos := &db.Position{
 			ID:         uuid.New(),
 			SessionID:  &session.ID,
-			Symbol:     "SOL/USDT",
+			Symbol:     "DOT/USDT",
 			Exchange:   "binance",
 			Side:       db.PositionSideLong,
 			EntryPrice: 100.0,


### PR DESCRIPTION
## Summary

Two related fixes from a PR #213 follow-up — both bugs surfaced when the integration test suite actually ran cleanly on PR #215 (the pgvector docker pull flake usually masks them).

### Bug 1 — `CreatePosition` / `CreatePositionTx` silently drop the entry-side fee

The Position struct exposes a `Fees` field and the production caller `internal/exchange/position_manager.go:268` (``openPosition``) sets `pos.Fees = entry-side commission` expecting it to round-trip. But `fees` was missing from the INSERT column list in both ``CreatePosition`` and ``CreatePositionTx``, so the row landed with ``fees = 0``. ``ClosePosition``'s accumulator then ran `fees = fees + close_fee` against 0 instead of the entry fee, so closed-position records under-reported total trading cost **by exactly the entry-side fee on every trade**.

This is a **real production data-integrity bug** that landed with #213 — every paper-traded position since #213 merged has incorrect fee accounting. Live mode is unaffected only because the affected callers all run through the paper-trading path.

Caught by ``TestClosePosition/close_LONG_computes_realized_pnl_from_CASE`` which expected ``fees=1.5`` (1.0 entry + 0.5 close) and observed ``0.5``.

The ``cmd/api/handlers_trading.go`` caller doesn't set ``Fees`` on the struct, so its behavior is unchanged.

### Bug 2 — `TestBulkUpdateUnrealizedPnL` test fixture violates unique partial index

``TestBulkUpdateUnrealizedPnL/updates_multiple_open_positions_in_one_round-trip`` created three positions in a loop with hardcoded ``Symbol: ""BTC/USDT""`` on the same session. Migration 019 adds a UNIQUE PARTIAL index ``idx_positions_open_session_symbol_uniq (session_id, symbol) WHERE exit_time IS NULL`` enforcing the "one open position per pair per session" invariant, so the second ``CreatePosition`` failed with a duplicate-key error.

Fixed by spreading across ``BTC/USDT``, ``ETH/USDT``, ``SOL/USDT`` — three distinct pairs still exercise the bulk update path while satisfying the uniqueness constraint.

## Impact

Both bugs block PR #215 (SEC-009 HMAC pepper) and PR #216 (SEC-006 + SEC-010) from going green on Integration Tests. They've been latent on main since #213 merged because the pgvector docker pull flake usually masks the integration test suite.

## Files changed

- ``internal/db/positions.go`` — add ``fees`` column to ``CreatePosition`` and ``CreatePositionTx`` INSERT statements
- ``internal/db/positions_bulk_pnl_integration_test.go`` — use distinct symbols per position
- ``internal/db/order_position_helpers_integration_test.go`` — refresh stale ""Fees field is not inserted"" comment

## Test plan

- [x] ``go build ./internal/db/...`` clean
- [x] ``go vet ./internal/db/...`` clean
- [x] ``golangci-lint run ./internal/db/...`` — 0 issues
- [x] ``go test -race -short ./internal/db/...`` ok (unit)
- [ ] CI Integration Tests run end-to-end with the fix

3 files changed, 35 insertions(+), 11 deletions(-)