### PR TITLE
fix(db): deduct full fee total from realized_pnl in ClosePosition (#218)

### DIFF
--- a/internal/db/positions.go
+++ b/internal/db/positions.go
@@ -276,32 +276,34 @@ func (db *DB) GetOpenPositionsTx(ctx context.Context, tx pgx.Tx, sessionID uuid.
 // returns rowsAffected=0 and is rejected, preserving the original
 // "already closed" semantics in one round-trip instead of two.
 //
-// Fee semantics — IMPORTANT contrast with ClosePositionTx:
-//   - ClosePosition (this function) ACCUMULATES via `fees = fees + $4`,
-//     so the row must already carry the entry-side fee at close time.
+// Fee semantics (unified in #218):
+//   - ClosePosition (this function) ACCUMULATES via `fees = fees + $4`
+//     and deducts the full accumulated total `(fees + $4)` from
+//     realized_pnl so the net P&L reflects both entry and exit costs.
 //   - ClosePositionTx OVERWRITES via `fees = $5` with a caller-computed
-//     entry+exit total.
-//   - realized_pnl in ClosePosition deducts only the close-side fee
-//     ($4); ClosePositionTx deducts the full caller-computed total.
-//
-// Both are correct individually but produce slightly different
-// realized_pnl on the same trade (ClosePosition's value is overstated
-// by the entry fee). Tracked for unification in #218 — DO NOT change
-// one path without the other.
+//     entry+exit total and deducts the same total from realized_pnl.
+//   - Both paths now produce identical realized_pnl for the same trade.
 func (db *DB) ClosePosition(ctx context.Context, id uuid.UUID, exitPrice float64, exitReason string, fees float64) error {
 	now := time.Now()
 	// Query parameters:
 	//   $1 = position id, $2 = exit_price, $3 = now (exit_time / updated_at),
-	//   $4 = fees (subtracted from realized_pnl AND added to running fees total),
+	//   $4 = close-side fee (added to running fees total AND included in
+	//        the realized_pnl deduction alongside the stored entry fee),
 	//   $5 = exit_reason.
+	//
+	// #218: realized_pnl now deducts (fees + $4) — the full accumulated
+	// total (entry + close) — instead of just $4 (close only). This
+	// aligns with ClosePositionTx which deducts the caller-computed
+	// entry+close total. Before this fix, realized_pnl was overstated
+	// by exactly the entry-side fee on every close.
 	const query = `
 		UPDATE positions
 		SET
 			exit_price = $2,
 			exit_time = $3,
 			realized_pnl = CASE
-				WHEN side = 'LONG'  THEN ($2 - entry_price) * quantity - $4
-				WHEN side = 'SHORT' THEN (entry_price - $2) * quantity - $4
+				WHEN side = 'LONG'  THEN ($2 - entry_price) * quantity - (fees + $4)
+				WHEN side = 'SHORT' THEN (entry_price - $2) * quantity - (fees + $4)
 				ELSE 0
 			END,
 			unrealized_pnl = 0,

--- a/internal/db/positions_close_integration_test.go
+++ b/internal/db/positions_close_integration_test.go
@@ -78,7 +78,7 @@ func TestClosePosition(t *testing.T) {
 		assert.Equal(t, "take_profit", *got.ExitReason)
 	})
 
-	t.Run("close SHORT computes realized_pnl with inverted sign", func(t *testing.T) {
+	t.Run("close SHORT computes realized_pnl with inverted sign and entry fees", func(t *testing.T) {
 		pos := &db.Position{
 			ID:         uuid.New(),
 			SessionID:  &session.ID,
@@ -88,17 +88,19 @@ func TestClosePosition(t *testing.T) {
 			EntryPrice: 3000.0,
 			Quantity:   1.0,
 			EntryTime:  time.Now(),
+			Fees:       0.75, // #218 R1: exercise (fees + $4) for SHORT too
 		}
 		require.NoError(t, tc.DB.CreatePosition(ctx, pos))
 
-		// Exit at 2900 on a SHORT, quantity 1.0, fees 0:
-		// realized_pnl = (3000 - 2900) * 1.0 - 0 = 100.0
-		require.NoError(t, tc.DB.ClosePosition(ctx, pos.ID, 2900.0, "stop_loss", 0.0))
+		// Exit at 2900 on a SHORT, qty 1.0, entry fees 0.75, close fees 0.25:
+		// #218: realized_pnl = (3000 - 2900) * 1.0 - (0.75 + 0.25) = 99.0
+		require.NoError(t, tc.DB.ClosePosition(ctx, pos.ID, 2900.0, "stop_loss", 0.25))
 
 		got, err := tc.DB.GetPosition(ctx, pos.ID)
 		require.NoError(t, err)
 		require.NotNil(t, got.RealizedPnL)
-		assert.InDelta(t, 100.0, *got.RealizedPnL, 0.0001)
+		assert.InDelta(t, 99.0, *got.RealizedPnL, 0.0001)
+		assert.InDelta(t, 1.0, got.Fees, 0.0001, "fees should accumulate (0.75 + 0.25)")
 	})
 
 	t.Run("double-close returns already closed", func(t *testing.T) {

--- a/internal/db/positions_close_integration_test.go
+++ b/internal/db/positions_close_integration_test.go
@@ -61,15 +61,16 @@ func TestClosePosition(t *testing.T) {
 		}
 		require.NoError(t, tc.DB.CreatePosition(ctx, pos))
 
-		// Exit at 51000 on a LONG, quantity 0.2, fees 0.5:
-		// realized_pnl = (51000 - 50000) * 0.2 - 0.5 = 199.5
+		// Exit at 51000 on a LONG, quantity 0.2, entry fees 1.0, close fees 0.5:
+		// #218: realized_pnl = (51000 - 50000) * 0.2 - (1.0 + 0.5) = 198.5
+		// (deducts the full accumulated fee total, not just the close fee)
 		require.NoError(t, tc.DB.ClosePosition(ctx, pos.ID, 51000.0, "take_profit", 0.5))
 
 		got, err := tc.DB.GetPosition(ctx, pos.ID)
 		require.NoError(t, err)
 		require.NotNil(t, got.ExitTime, "exit_time should be set")
 		require.NotNil(t, got.RealizedPnL, "realized_pnl should be populated")
-		assert.InDelta(t, 199.5, *got.RealizedPnL, 0.0001)
+		assert.InDelta(t, 198.5, *got.RealizedPnL, 0.0001)
 		assert.InDelta(t, 1.5, got.Fees, 0.0001, "fees should accumulate (1.0 + 0.5)")
 		require.NotNil(t, got.ExitPrice)
 		assert.InDelta(t, 51000.0, *got.ExitPrice, 0.0001)


### PR DESCRIPTION
## Summary

Closes #218 — ClosePosition vs ClosePositionTx realized_pnl asymmetry on entry fees.

### The bug

``ClosePosition``'s SQL deducted only the close-side fee (``$4``) from ``realized_pnl``, but accumulated the full entry+close total in the ``fees`` column (``fees = fees + $4``). This meant **realized_pnl was overstated by exactly the entry-side fee on every close** — a data integrity issue affecting P&L reporting and reconciliation.

``ClosePositionTx`` was already correct (deducts the full caller-computed total).

### The fix

One SQL change in the ``realized_pnl`` CASE expression:

```sql
-- Before (close fee only):
realized_pnl = ($2 - entry_price) * quantity - $4

-- After (full accumulated total):
realized_pnl = ($2 - entry_price) * quantity - (fees + $4)
```

``(fees + $4)`` reads the stored entry-side fee from the row and adds the close-side fee, producing the net P&L after all trading costs — matching ``ClosePositionTx``'s semantics.

### Example

Position: entry=50000, exit=51000, qty=0.2, entry_fee=1.0, close_fee=0.5

| | Before | After |
|---|---|---|
| ``realized_pnl`` | 199.5 (overstated) | 198.5 (correct) |
| ``fees`` | 1.5 | 1.5 |

### Test updated

``TestClosePosition/close_LONG_computes_realized_pnl_from_CASE``: assertion changed from 199.5 to 198.5.

### Backfill note

Rows closed via the non-Tx path between PR #217 (which started persisting entry fees) and this fix have ``realized_pnl`` overstated by their entry-side fee. These can be identified by ``hash_algorithm IS NULL`` (pre-#217 rows have ``fees=0`` so the asymmetry was invisible) and corrected with:

```sql
UPDATE positions
SET realized_pnl = CASE
    WHEN side = 'LONG' THEN (exit_price - entry_price) * quantity - fees
    WHEN side = 'SHORT' THEN (entry_price - exit_price) * quantity - fees
END
WHERE exit_time IS NOT NULL AND fees > 0;
```

## Test plan

- [x] ``go build ./internal/db/...`` clean
- [x] ``go test -race -short ./internal/db/...`` green
- [x] ``golangci-lint`` 0 issues
- [ ] CI Integration Tests

2 files changed, 20 insertions(+), 17 deletions(-)